### PR TITLE
[SDK-553] feat: refactor and extracted shared logic

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @HarrisonHough, @rYuuk will be requested for
+# review when someone opens a pull request.
+*       @readyplayerme/onboarding-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @HarrisonHough, @rYuuk will be requested for
+# @readyplayerme/onboarding-integrations be requested for
 # review when someone opens a pull request.
 *       @readyplayerme/onboarding-integrations

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Files**
+
+Attach or link to .glb files or avatar URL that trigger the bug. 
+
+In addition, make sure to run those files through the example scenes first. If you encounter errors or warnings, try to make sure they are not responsible for the issue.
+
+> Note: You have to ZIP archive them first in order for GitHub to accept the upload.
+If your files are confidential:
+
+- Try to create a similar, but intellectual-property-free Unity example project or build that reproduces the bug in the same way (so any community member can have a look)
+- Otherwise, still create this issue and send the files (or a link to them) discretely via email
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - Ready Player Me Core version
+ - Ready Player Me WebView version (If relevant)
+ - glTFast version
+ - Unity Editor version [e.g. 2021.2.1f1]
+ - Render Pipeline and version [e.g. Universal Render Pipeline 12.0]
+ - Operating System [e.g. Windows, Mac, Linux ]
+ - Platform: [e.g. Editor , Windows Player, iOS]
+ 
+additionally (if significant for the bug):
+
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - For WebGL: Browser [e.g. stock browser, safari]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. e.g. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-﻿<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
+<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
 <!-- PR name should look like: [TICKETID] My Pull Request -->
 
 <!-- Add link for the ticket here editing the TICKETID-->
@@ -9,7 +9,7 @@
 
 -   Briefly describe what this change will do
 
-<!-- Fill the section below with Added, Updated and Removed. -->
+<!-- Fill the section below with Added, Updated and Removed information. -->
 <!-- If there is no item under one of the lists remove it's title. -->
 
 <!-- Testability -->
@@ -22,4 +22,11 @@
 
 ## Checklist
 
+-   [ ] Tests written or updated for the changes.
 -   [ ] Documentation is updated.
+-   [ ] Changelog is updated.
+
+<!--- Remember to copy the Changes Section into the commit message when you close the PR -->
+
+
+

--- a/Editor/ReadyPlayerMe.NetcodeSupport.Editor.asmdef
+++ b/Editor/ReadyPlayerMe.NetcodeSupport.Editor.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "ReadyPlayerMe.NetcodeSupport.Editor",
     "rootNamespace": "",
-    "references": [],
+    "references": [
+        "ReadyPlayerMe.Core.Editor"
+    ],
     "includePlatforms": [
         "Editor"
     ],

--- a/Editor/TransferPrefab.cs
+++ b/Editor/TransferPrefab.cs
@@ -6,12 +6,13 @@ namespace ReadyPlayerMe.NetcodeSupport.Editor
 {
     public static class TransferPrefab
     {
-        private const string PREFAB_PATH = "Assets/Ready Player Me/Resources/RPM_Netcode_Character.prefab";
+        private const string NEW_PREFAB_PATH = "Assets/Ready Player Me/Resources/RPM_Netcode_Character.prefab";
+        private const string PREFAB_ASSET_NAME = "t:prefab RPM_Netcode_Character";
 
         [MenuItem("Ready Player Me/Transfer Netcode Prefab", priority = 34)]
         public static void Transfer()
         {
-            string[] guids = AssetDatabase.FindAssets("t:prefab RPM_Netcode_Character");
+            var guids = AssetDatabase.FindAssets(PREFAB_ASSET_NAME);
 
             if (guids.Length == 0)
             {
@@ -19,15 +20,15 @@ namespace ReadyPlayerMe.NetcodeSupport.Editor
             }
             else
             {
-                if (AssetDatabase.LoadAssetAtPath(PREFAB_PATH, typeof(GameObject)))
+                if (AssetDatabase.LoadAssetAtPath(NEW_PREFAB_PATH, typeof(GameObject)))
                 {
                     if (!EditorUtility.DisplayDialog("Warning", "RPM_Netcode_Character prefab already exists. Do you want to overwrite it?", "Yes", "No"))
                     {
                         return;
                     }
                 }
-                PrefabTransferHelper.TransferPrefabByGuid(guids[0], PREFAB_PATH);
-                Debug.Log($"Netcode prefab transferred to {PREFAB_PATH}");
+                PrefabTransferHelper.TransferPrefabByGuid(guids[0], NEW_PREFAB_PATH);
+                Debug.Log($"Netcode prefab transferred to {NEW_PREFAB_PATH}");
             }
         }
     }

--- a/Editor/TransferPrefab.cs
+++ b/Editor/TransferPrefab.cs
@@ -1,3 +1,4 @@
+using ReadyPlayerMe.Core.Editor;
 using UnityEditor;
 using UnityEngine;
 
@@ -18,17 +19,14 @@ namespace ReadyPlayerMe.NetcodeSupport.Editor
             }
             else
             {
-                if (AssetDatabase.LoadAssetAtPath("Assets/Ready Player Me/Resources/RPM_Character.prefab", typeof(GameObject)))
+                if (AssetDatabase.LoadAssetAtPath(PREFAB_PATH, typeof(GameObject)))
                 {
-                    if (!EditorUtility.DisplayDialog("Warning", "RPM_Character prefab already exists. Do you want to overwrite it?", "Yes", "No"))
+                    if (!EditorUtility.DisplayDialog("Warning", "RPM_Netcode_Character prefab already exists. Do you want to overwrite it?", "Yes", "No"))
                     {
                         return;
                     }
                 }
-
-                string path = AssetDatabase.GUIDToAssetPath(guids[0]);
-                AssetDatabase.CopyAsset(path, PREFAB_PATH);
-                Selection.activeObject = AssetDatabase.LoadAssetAtPath(PREFAB_PATH, typeof(GameObject));
+                PrefabTransferHelper.TransferPrefabByGuid(guids[0], PREFAB_PATH);
                 Debug.Log($"Netcode prefab transferred to {PREFAB_PATH}");
             }
         }


### PR DESCRIPTION
﻿<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [SDK-553](https://ready-player-me.atlassian.net/browse/SDK-553)

## Description

-   This change removes the shared logic from the netcode plugin into core so it can re-used in other packages (like Photon networking example for instance) 

<!-- Fill the section below with Added, Updated and Removed. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   to test you can create a new project and import these 3 packages. 
https://github.com/readyplayerme/rpm-unity-sdk-core.git#feature/extract-network-shared-logic
https://github.com/readyplayerme/rpm-unity-sdk-netcode-support.git#feature/extract-shared-logic
https://github.com/readyplayerme/rpm-unity-sdk-photon-support.git#feature/remove-shared-logic
After that is done you need to check for errors (both in editor and running the sample scenes)
Then Also try the TransferPrefab menu items. 

![image](https://github.com/readyplayerme/rpm-unity-sdk-netcode-support/assets/7085672/cbd858fa-f6d4-4e21-a508-8ed8935ece2b)


<!-- Update your progress with the task here -->

## Checklist

-   [ ] Documentation is updated.


[SDK-553]: https://ready-player-me.atlassian.net/browse/SDK-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ